### PR TITLE
comment out rest_framework_jwt dependency in logout

### DIFF
--- a/rest_auth/views.py
+++ b/rest_auth/views.py
@@ -128,10 +128,10 @@ class LogoutView(APIView):
 
         response = Response({"detail": _("Successfully logged out.")},
                             status=status.HTTP_200_OK)
-        if getattr(settings, 'REST_USE_JWT', False):
-            from rest_framework_jwt.settings import api_settings as jwt_settings
-            if jwt_settings.JWT_AUTH_COOKIE:
-                response.delete_cookie(jwt_settings.JWT_AUTH_COOKIE)
+        # if getattr(settings, 'REST_USE_JWT', False):
+        #     from rest_framework_jwt.settings import api_settings as jwt_settings
+        #     if jwt_settings.JWT_AUTH_COOKIE:
+        #         response.delete_cookie(jwt_settings.JWT_AUTH_COOKIE)
         return response
 
 


### PR DESCRIPTION
I have just comment out dependency of rest_framework_jwt package in logout view, because of error. 

django-rest-framework-simplejwt don't have logout functionality so there is no extra logic that this api could have instead...